### PR TITLE
Changes since 1-0

### DIFF
--- a/Portal11/Account/LoginDispatch.aspx.cs
+++ b/Portal11/Account/LoginDispatch.aspx.cs
@@ -41,16 +41,10 @@ namespace Portal11.Account
             using (Models.ApplicationDbContext context = new Models.ApplicationDbContext())
             {
                 var userMgr = new UserManager<ApplicationUser>(new UserStore<ApplicationUser>(context)); // Open path to User Manager
-                ApplicationUser loggedInUser = userMgr.FindByEmail(email);             // Look for an existing user
-
-                //var query = from u in context.Users
-                //            where u.Email == email
-                //            select u;
-                //ApplicationUser loggedInUser = query.SingleOrDefault(); // Fetch the ApplicationUser record for the logged in user
+                ApplicationUser loggedInUser = userMgr.FindByEmail(email); // Look for an existing user
                 if (loggedInUser == null)                               // Cannot re-locate record used during login
                 {
-                    LogError.LogInternalError("LoginDispatch", string.Format("Unable to find User with email '{0}' in database",
-                        email));                                        // Fatal error
+                    LogError.LogInternalError("LoginDispatch", $"Unable to find User with email '{email}' in database"); // Fatal error
                 }
 
                 // If the User's account is Inactive, log them right back out again.
@@ -94,6 +88,7 @@ namespace Portal11.Account
                 userInfoCookie[PortalConstants.CUserID] = loggedInUser.Id;
                 userInfoCookie[PortalConstants.CUserFullName] = loggedInUser.FullName;
                 userInfoCookie[PortalConstants.CUserFranchiseKey] = loggedInUser.FranchiseKey; // Insert current User's Franchise Key
+                userInfoCookie[PortalConstants.CUserGridViewRows] = loggedInUser.GridViewRows.ToString(); // Find number of rows to display in GridView controls
 
                 // The User could be both an Administrator and something else. So we check for Administrator first and fill in one of its cookie fields. 
                 //

--- a/Portal11/Admin/EditEntity.aspx.cs
+++ b/Portal11/Admin/EditEntity.aspx.cs
@@ -148,7 +148,12 @@ namespace Portal11.Admin
                 }
                 catch (Exception ex)
                 {
-                    LogError.LogDatabaseError(ex, "EditEntity", "Error updating Entity row"); // Fatal error
+                    if (ExceptionActions.IsDuplicateKeyException(ex))       // If true this is a Duplicate Key exception
+                    {
+                        litDangerMessage.Text = $"Another Entity with the name '{txtName.Text}' already exists. Entity Names must be unique.";
+                        return;                                             // Report the error to user and try again
+                    }
+                    LogError.LogDatabaseError(ex, "EditEntity", "Error updating Entity row"); // Otherwise, log a Fatal error and don't return here
                 }
             }
 

--- a/Portal11/Admin/EditGLCode.aspx.cs
+++ b/Portal11/Admin/EditGLCode.aspx.cs
@@ -131,6 +131,11 @@ namespace Portal11.Admin
                 }
                 catch (Exception ex)
                 {
+                    if (ExceptionActions.IsDuplicateKeyException(ex))       // If true this is a Duplicate Key exception
+                    {
+                        litDangerMessage.Text = $"Another GLCode with the code '{txtCode.Text}' already exists. GLCodes must be unique.";
+                        return;                                             // Report the error to user and try again
+                    }
                     LogError.LogDatabaseError(ex, "EditGLCode", "Error writing GLCode row"); // Fatal error
                 }
             }

--- a/Portal11/Admin/EditPerson.aspx.cs
+++ b/Portal11/Admin/EditPerson.aspx.cs
@@ -144,6 +144,11 @@ namespace Portal11.Admin
                 }
                 catch (Exception ex)
                 {
+                    if (ExceptionActions.IsDuplicateKeyException(ex))       // If true this is a Duplicate Key exception
+                    {
+                        litDangerMessage.Text = $"Another Person with the name '{txtName.Text}' already exists. Person Names must be unique.";
+                        return;                                             // Report the error to user and try again
+                    }
                     LogError.LogDatabaseError(ex, "EditPerson", "Error updating Person row"); // Fatal error
                 }
             }

--- a/Portal11/Admin/EditProject.aspx
+++ b/Portal11/Admin/EditProject.aspx
@@ -56,9 +56,50 @@
         <asp:Panel ID="pnlBalanceDate" runat="server">
             <div class="form-group">
                 <div class="row">
-                    <asp:Label runat="server" AssociatedControlID="txtBalanceDate" CssClass="col-sm-2 col-xs-12 control-label" Font-Bold="false">Balance Date</asp:Label>
-                    <div class="col-lg-4 col-md-4 col-xs-6">
-                        <asp:TextBox runat="server" ID="txtBalanceDate" CssClass="form-control" ReadOnly="true" />
+                    <asp:Label ID="lblBalanceDate" runat="server" AssociatedControlID="txtBalanceDate" Font-Bold="false"
+                        CssClass="col-sm-offset-0 col-sm-2 col-xs-offset-1 col-xs-11 control-label">Balance Date</asp:Label>
+                    <div class="col-lg-3 col-md-4 col-sm-offset-0 col-xs-offset-1 col-xs-6">
+                        <div class="input-group">
+                            <asp:TextBox runat="server" ID="txtBalanceDate" CssClass="form-control has-success"
+                                 OnTextChanged="txtBalanceDate_TextChanged" AutoPostBack="true" ></asp:TextBox>
+                            <span class="input-group-addon">
+                                <asp:LinkButton runat="server" ID="btnBalanceDate" CssClass="btn-xs btn-default"
+                                    OnClick="btnBalanceDate_Click" CausesValidation="false">
+                                    <span aria-hidden="true" class="glyphicon glyphicon-calendar" > </span>
+                                </asp:LinkButton>
+                            </span>
+                        </div>
+
+                        <asp:Calendar ID="calBalanceDate" runat="server" Visible="false"
+                            OnSelectionChanged="calBalanceDate_SelectionChanged"
+                            DayNameFormat="Short"
+                            SelectionMode="Day"
+                            Font-Names="Verdana" Font-Size="12px"
+                            Height="180px" Width="275px"
+                            TodayDayStyle-Font-Bold="True"
+                            DayHeaderStyle-Font-Bold="True"
+                            OtherMonthDayStyle-ForeColor="gray"
+                            TitleStyle-BackColor="#18bc9c"
+                            TitleStyle-ForeColor="white"
+                            TitleStyle-Font-Bold="True"
+                            SelectedDayStyle-BackColor="#f39c12"
+                            SelectedDayStyle-Font-Bold="True"
+                            NextPrevFormat="ShortMonth"
+                            NextPrevStyle-ForeColor="white"
+                            NextPrevStyle-Font-Size="10px"
+                            SelectorStyle-BackColor="#3498db"
+                            SelectorStyle-ForeColor="white"
+                            SelectorStyle-Font-Size="10px"
+                            SelectWeekText="week"
+                            SelectMonthText="month" />
+                    </div>
+                    <div class="col-lg-6 col-md-6 col-sm-offset-0 col-xs-offset-1 col-xs-6">
+<%--                        <asp:RequiredFieldValidator runat="server" ControlToValidate="txtBalanceDate"
+                            CssClass="text-danger" ErrorMessage="Please supply a Date." />--%>
+                        <asp:RegularExpressionValidator ID="valBalanceDate" runat="server" ControlToValidate="txtBalanceDate"
+                            CssClass="text-danger" ErrorMessage="Date format is dd/mm/yyyy"
+                            ValidationExpression="^([0-9]{1,2})[./-]+([0-9]{1,2})[./-]+([0-9]{2}|[0-9]{4})$">
+                        </asp:RegularExpressionValidator>
                     </div>
                 </div>
             </div>

--- a/Portal11/Admin/EditProject.aspx.designer.cs
+++ b/Portal11/Admin/EditProject.aspx.designer.cs
@@ -94,6 +94,15 @@ namespace Portal11.Admin {
         protected global::System.Web.UI.WebControls.Panel pnlBalanceDate;
         
         /// <summary>
+        /// lblBalanceDate control.
+        /// </summary>
+        /// <remarks>
+        /// Auto-generated field.
+        /// To modify move field declaration from designer file to code-behind file.
+        /// </remarks>
+        protected global::System.Web.UI.WebControls.Label lblBalanceDate;
+        
+        /// <summary>
         /// txtBalanceDate control.
         /// </summary>
         /// <remarks>
@@ -101,6 +110,33 @@ namespace Portal11.Admin {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.TextBox txtBalanceDate;
+        
+        /// <summary>
+        /// btnBalanceDate control.
+        /// </summary>
+        /// <remarks>
+        /// Auto-generated field.
+        /// To modify move field declaration from designer file to code-behind file.
+        /// </remarks>
+        protected global::System.Web.UI.WebControls.LinkButton btnBalanceDate;
+        
+        /// <summary>
+        /// calBalanceDate control.
+        /// </summary>
+        /// <remarks>
+        /// Auto-generated field.
+        /// To modify move field declaration from designer file to code-behind file.
+        /// </remarks>
+        protected global::System.Web.UI.WebControls.Calendar calBalanceDate;
+        
+        /// <summary>
+        /// valBalanceDate control.
+        /// </summary>
+        /// <remarks>
+        /// Auto-generated field.
+        /// To modify move field declaration from designer file to code-behind file.
+        /// </remarks>
+        protected global::System.Web.UI.WebControls.RegularExpressionValidator valBalanceDate;
         
         /// <summary>
         /// pnlCurrentFunds control.

--- a/Portal11/App_Readme/WhatsNew.txt
+++ b/Portal11/App_Readme/WhatsNew.txt
@@ -1,4 +1,23 @@
-﻿Version 0.7
+﻿Version 1.1
+
+For Entities, GL Codes, Persons, and Projects, the Portal now requires that names be unique. That is, duplicate names are not allowed.
+In all Grids, the number of rows per page is now controlled by a user-specific parameter. This can be adjusted on the Edit Portal User page.
+On Edit Project, the Balance Date can now be edited.
+In Project Dashboard and Staff Dashboard, a bug in pagination of request lists is fixed.
+A bug that prevented Staff from Reviewing Approvals is fixed.
+In Project Dashboard, a Project Director can now archive a Deposit Request.
+A Gift Card is now called a PEX Card.
+
+Version 1.0 - First production use
+
+On all Select Pages, display Inactive column only if Inactive checkbox is checked.
+Bring Project Director to correct page - Project Dashboard - after reviewing a request.
+
+Version 0.8
+
+On the Project Dashboard, the "Awaiting CW Staff" option is now checked by default.
+
+Version 0.7
 
 Approvals of Certificate of Insurance no longer require any Supporting Documents
 Projects can create Deposit and Expense requests before Entities and Persons are assigned to the project.

--- a/Portal11/App_Start/Startup.Auth.cs
+++ b/Portal11/App_Start/Startup.Auth.cs
@@ -33,6 +33,11 @@ namespace Portal11
                     OnValidateIdentity = SecurityStampValidator.OnValidateIdentity<ApplicationUserManager, ApplicationUser>(
                         validateInterval: TimeSpan.FromMinutes(30),
                         regenerateIdentity: (manager, user) => user.GenerateUserIdentityAsync(manager))
+
+                        //TODO: Remove the following clause when underlying problem is identified
+                        ,OnException = (context =>
+                        { throw context.Exception; }
+                        )
                 }
             });
             // Use a cookie to temporarily store information about a user logging in with a third party login provider

--- a/Portal11/ErrorLog/LogError.cs
+++ b/Portal11/ErrorLog/LogError.cs
@@ -54,7 +54,7 @@ namespace Portal11.ErrorLog
         public static void LogDatabaseError(Exception ex, string pageName, string errorMessage)
         {
             try
-            {
+            { 
                 string secondaryError = "";                             // Start with no secondary error message      
                 if (ex is DbEntityValidationException)                  // If is error is a validation exception. Interpret details
                 {
@@ -110,7 +110,7 @@ namespace Portal11.ErrorLog
             }
             catch (Exception)
             {
-                // uh oh! just keep going
+                ; // uh oh! just keep going
             }
         }
 

--- a/Portal11/Global.asax.cs
+++ b/Portal11/Global.asax.cs
@@ -37,11 +37,11 @@ namespace Portal11
 
             // A debugging option: Always toss the existing database and re-create it
 
-            Database.SetInitializer(new PortalDatabaseInitializer()); // One-shot to fill empty database with tables
+//            Database.SetInitializer(new PortalDatabaseInitializer()); // One-shot to fill empty database with tables
 
             // The "production" option. Use the Initializer to execute migrations if the model has changed.
 
-//            Database.SetInitializer(new MigrateDatabaseToLatestVersion<ApplicationDbContext, Portal11.Migrations.Configuration>());
+            Database.SetInitializer(new MigrateDatabaseToLatestVersion<ApplicationDbContext, Portal11.Migrations.Configuration>());
 
             // Create custom user roles if they don't already exist
 

--- a/Portal11/Lists/ListPortalUsers.aspx.cs
+++ b/Portal11/Lists/ListPortalUsers.aspx.cs
@@ -23,6 +23,7 @@ namespace Portal11.Lists
                 // If the page before us has left a Query String with a status message, find it and display it
 
                 NavigationActions.ProcessSeverityStatus(litSuccessMessage, litDangerMessage);
+                AllPortalUsersView.PageSize = CookieActions.FindGridViewRows(); // Set number of rows per page in grid
                 LoadUserView();                                         // Fill the grid
             }
         }

--- a/Portal11/Logic/CookieActions.cs
+++ b/Portal11/Logic/CookieActions.cs
@@ -13,52 +13,100 @@ namespace Portal11.Logic
 
         public static void DeleteLoginInfoCookie()
         {
-            if (HttpContext.Current.Request.Cookies[PortalConstants.CLoginInfo] != null) // if != stale Login cookie currently exists, delete it
+            try
             {
-                HttpCookie staleCookie = new HttpCookie(PortalConstants.CLoginInfo); // Fetch stale cookie (from last user login)
-                staleCookie.Expires = DateTime.Now.AddDays(-1d);        // Ask cookie to expire immediately
-                HttpContext.Current.Response.Cookies.Add(staleCookie);  // and update cookie into oblivion
+                if (HttpContext.Current.Request.Cookies[PortalConstants.CLoginInfo] != null) // if != stale Login cookie currently exists, delete it
+                {
+                    HttpCookie staleCookie = new HttpCookie(PortalConstants.CLoginInfo); // Fetch stale cookie (from last user login)
+                    staleCookie.Expires = DateTime.Now.AddDays(-1d);        // Ask cookie to expire immediately
+                    HttpContext.Current.Response.Cookies.Add(staleCookie);  // and update cookie into oblivion
+                }
+            }
+            catch (NullReferenceException e)
+            {
+                ;                                                           // Just continue in spite of the error
             }
             return;
-        }
+            }
 
         public static void DeleteUserInfoCookie()
         {
-            if (HttpContext.Current.Request.Cookies[PortalConstants.CUserInfo] != null) // if != stale User cookie currently exists, delete it
+            try
+            { 
+                if (HttpContext.Current.Request.Cookies[PortalConstants.CUserInfo] != null) // if != stale User cookie currently exists, delete it
+                {
+                    HttpCookie staleCookie = new HttpCookie(PortalConstants.CUserInfo); // Fetch stale cookie (from last user login)
+                    staleCookie.Expires = DateTime.Now.AddDays(-1d);        // Ask cookie to expire immediately
+                    HttpContext.Current.Response.Cookies.Add(staleCookie);  // and update cookie into oblivion
+                }
+            }
+            catch (NullReferenceException e)
             {
-                HttpCookie staleCookie = new HttpCookie(PortalConstants.CUserInfo); // Fetch stale cookie (from last user login)
-                staleCookie.Expires = DateTime.Now.AddDays(-1d);        // Ask cookie to expire immediately
-                HttpContext.Current.Response.Cookies.Add(staleCookie);  // and update cookie into oblivion
+                ;                                                           // Just continue in spite of the error
             }
             return;
         }
 
         public static void DeleteProjectInfoCookie()
         {
-            if (HttpContext.Current.Request.Cookies[PortalConstants.CProjectInfo] != null)  // if != stale Project cookie currently exists, delete it
+            try
+            { 
+                if (HttpContext.Current.Request.Cookies[PortalConstants.CProjectInfo] != null)  // if != stale Project cookie currently exists, delete it
+                {
+                    HttpCookie staleCookie = new HttpCookie(PortalConstants.CProjectInfo); // Fetch stale cookie (from last user login)
+                    staleCookie.Expires = DateTime.Now.AddDays(-1d);        // Ask cookie to expire immediately
+                    HttpContext.Current.Response.Cookies.Add(staleCookie);  // and update cookie into oblivion
+                }
+            }
+            catch (NullReferenceException e)
             {
-                HttpCookie staleCookie = new HttpCookie(PortalConstants.CProjectInfo); // Fetch stale cookie (from last user login)
-                staleCookie.Expires = DateTime.Now.AddDays(-1d);        // Ask cookie to expire immediately
-                HttpContext.Current.Response.Cookies.Add(staleCookie);  // and update cookie into oblivion
+                ;                                                           // Just continue in spite of the error
             }
             return;
         }
 
         public static void DeleteCheckboxCookies()
         {
-            if (HttpContext.Current.Request.Cookies[PortalConstants.CProjectCheckboxes] != null) // If != stale Project Checkboxes cookie currently exists, delete it
-            {
-                HttpCookie staleCookie = new HttpCookie(PortalConstants.CProjectCheckboxes); // Fetch stale cookie
-                staleCookie.Expires = DateTime.Now.AddDays(-1d);        // Ask cookie to expire immediately
-                HttpContext.Current.Response.Cookies.Add(staleCookie);  // and update cookie into oblivion
+            try
+            { 
+                if (HttpContext.Current.Request.Cookies[PortalConstants.CProjectCheckboxes] != null) // If != stale Project Checkboxes cookie currently exists, delete it
+                {
+                    HttpCookie staleCookie = new HttpCookie(PortalConstants.CProjectCheckboxes); // Fetch stale cookie
+                    staleCookie.Expires = DateTime.Now.AddDays(-1d);        // Ask cookie to expire immediately
+                    HttpContext.Current.Response.Cookies.Add(staleCookie);  // and update cookie into oblivion
+                }
+                if (HttpContext.Current.Request.Cookies[PortalConstants.CStaffCheckboxes] != null) // If != stale Staff Checkboxes cookie currently exists, delete it
+                {
+                    HttpCookie staleCookie = new HttpCookie(PortalConstants.CStaffCheckboxes); // Fetch stale cookie
+                    staleCookie.Expires = DateTime.Now.AddDays(-1d);        // Ask cookie to expire immediately
+                    HttpContext.Current.Response.Cookies.Add(staleCookie);  // and update cookie into oblivion
+                }
             }
-            if (HttpContext.Current.Request.Cookies[PortalConstants.CStaffCheckboxes] != null) // If != stale Staff Checkboxes cookie currently exists, delete it
+            catch (NullReferenceException e)
             {
-                HttpCookie staleCookie = new HttpCookie(PortalConstants.CStaffCheckboxes); // Fetch stale cookie
-                staleCookie.Expires = DateTime.Now.AddDays(-1d);        // Ask cookie to expire immediately
-                HttpContext.Current.Response.Cookies.Add(staleCookie);  // and update cookie into oblivion
+                ;                                                           // Just continue in spite of the error
             }
             return;
+        }
+
+        // Look in the UserInfoCookie to find a value for number of rows per GridView control. Lots of range checks and boundary conditions
+        public static int FindGridViewRows()
+        {
+            try
+            {
+                HttpCookie userInfoCookie = HttpContext.Current.Request.Cookies[PortalConstants.CUserInfo]; // Fetch cookie, if it exists
+                if (userInfoCookie != null)                                 // If != cookie exists
+                { 
+                    int value = Convert.ToInt32(userInfoCookie[PortalConstants.CUserGridViewRows]); // Ask cookie for value
+                    if ((value >= ApplicationUser.GridViewRowsMinimum) && (value <= ApplicationUser.GridViewRowsMaximum)) // If true, value from cookie is in range
+                        return value;                                       // Give "legal" value to caller
+                }
+            }
+            catch (Exception)
+            {
+                ;                                                           // Just continue in spite of the error
+            }
+            return ApplicationUser.GridViewRowsDefault;                     // Cookie value not available. Return default value
         }
 
         // Make a ProjectInfoCookie to describe the current User's relationship with their selected project.  Two versions

--- a/Portal11/Logic/NavigationActions.cs
+++ b/Portal11/Logic/NavigationActions.cs
@@ -62,9 +62,9 @@ namespace Portal11.Logic
         // Fill a particular GridView - EDHistoryView - with rows from the EDHistory table. Unusually, this GridView is used identically
         // by four pages, so filling it is factored here.
 
-
         public static void LoadAllAppHistorys(int appID, GridView EDHistoryView)
         {
+            EDHistoryView.PageSize = CookieActions.FindGridViewRows();  // Set number of rows per page in grid
             using (Models.ApplicationDbContext context = new Models.ApplicationDbContext())
             {
                 var query = from edh in context.AppHistorys
@@ -99,6 +99,7 @@ namespace Portal11.Logic
 
         public static void LoadAllDepHistorys(int depID, GridView EDHistoryView)
         {
+            EDHistoryView.PageSize = CookieActions.FindGridViewRows();  // Set number of rows per page in grid
             using (Models.ApplicationDbContext context = new Models.ApplicationDbContext())
             {
                 var query = from edh in context.DepHistorys
@@ -133,6 +134,7 @@ namespace Portal11.Logic
 
         public static void LoadAllExpHistorys(int expID, GridView EDHistoryView)
         {
+            EDHistoryView.PageSize = CookieActions.FindGridViewRows();  // Set number of rows per page in grid
             using (Models.ApplicationDbContext context = new Models.ApplicationDbContext())
             {
                 var query = from edh in context.ExpHistorys

--- a/Portal11/Migrations/Configuration.cs
+++ b/Portal11/Migrations/Configuration.cs
@@ -10,6 +10,7 @@ namespace Portal11.Migrations
         public Configuration()
         {
             AutomaticMigrationsEnabled = true;
+            AutomaticMigrationDataLossAllowed = true;                   // A little risky, but we only turn this on rarely
             ContextKey = "Portal11.Models.ApplicationDbContext";
         }
 
@@ -17,10 +18,10 @@ namespace Portal11.Migrations
         {
             //  This method will be called after migrating to the latest version.
 
-            context.Persons.AddOrUpdate(
-                p => p.Name,
-                new Models.Person { Name = "Doe, Jane", Address = "123 Anywhere St.\r\nPhiladelphia, PA 19000", Phone = "215-123-4567", Email = "Jane.doe@def.org", CreatedTime = System.DateTime.Now }
-                );
+            //context.Persons.AddOrUpdate(
+            //    p => p.Name,
+            //    new Models.Person { Name = "Doe, Jane", Address = "123 Anywhere St.\r\nPhiladelphia, PA 19000", Phone = "215-123-4567", Email = "Jane.doe@def.org", CreatedTime = System.DateTime.Now }
+            //    );
 
             //                pers.FranchiseKey = Franchise.LocalFranchiseKey;
             //pers.Inactive = false;

--- a/Portal11/Models/IdentityModels.cs
+++ b/Portal11/Models/IdentityModels.cs
@@ -21,9 +21,10 @@ namespace Portal11.Models
         [Required]
         public string FranchiseKey { get; set; }
         public bool Inactive { get; set; }
+        public const int InactiveColumn = 3;                            // Column when displayed in GridView
 
         [StringLength(50)]
-        public string FullName { get; set; }                              // The built-in UserName field seems conflated with Email, so provide alternative
+        public string FullName { get; set; }                            // The built-in UserName field seems conflated with Email, so provide alternative
 
         [StringLength(250), DataType(DataType.MultilineText)]
         public string Address { get; set; }
@@ -38,6 +39,9 @@ namespace Portal11.Models
         public const int GridViewRowsMaximum = 100;                     // Can't go bigger than this
         public int LoginCount { get; set; }                             // Number of successful logins
         public DateTime LastLogin { get; set; }                         // Time of last successful login
+        public bool NoEmailOnApprove { get; set; }                      // Don't Send Project Director email when request is approved
+        public bool NoEmailOnReturn { get; set; }                       // Don't Send Project Director email when request is returned
+        public bool NoEmailOnRefer { get; set; }                        // Don't Send Project Director email when request is referred for approval
 
         // End of new fields
         //// Define names of user roles

--- a/Portal11/Models/PortalDatabaseInitializer.cs
+++ b/Portal11/Models/PortalDatabaseInitializer.cs
@@ -424,6 +424,9 @@ namespace Portal11.Models
             gl.Code = "63018 — Postage & Shipping";
             context.GLCodes.Add(gl); context.SaveChanges();
 
+            gl.Code = "63019 — Printing and Publication";
+            context.GLCodes.Add(gl); context.SaveChanges();
+
             gl.Code = "63000 — PROGRAM / GENERAL ADMIN: 63019 — Printing & Publications";
             context.GLCodes.Add(gl); context.SaveChanges();
 

--- a/Portal11/Models/PortalModels.cs
+++ b/Portal11/Models/PortalModels.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel;
+using System.ComponentModel.DataAnnotations.Schema;
 
 namespace Portal11.Models
 {
@@ -43,7 +44,7 @@ namespace Portal11.Models
         public int LoginCount { get; set; }
         public DateTime LastLogin { get; set; }
         public string Inactive { get; set; }
-        public const int InactiveColumn = 6;
+        public const int InactiveColumn = 7;
     }
 
     // One row of the GridView named AllAppView, used by ProjectDashboard
@@ -452,11 +453,12 @@ namespace Portal11.Models
     public class Entity
     {
         public int EntityID { get; set; }
-        [Required]
+        [Required, StringLength(20), Index("FranchiseAndEntity", 1)]
         public string FranchiseKey { get; set; }
         public bool Inactive { get; set; }
+        public const int InactiveColumn = 3;                // Column when displayed in GridView
         public EntityType EntityType { get; set; }
-        [Required, StringLength(100)]
+        [Required, StringLength(100), Index("FranchiseAndEntity", 2, IsUnique = true)]
         public string Name { get; set; }
         [StringLength(250), DataType(DataType.MultilineText)]
         public string Address { get; set; }
@@ -512,7 +514,7 @@ namespace Portal11.Models
         public DateTime BeginningDate { get; set; }         // Pay Period for Paycheck
         public DateTime EndingDate { get; set; }
 
-        public int CardsQuantity { get; set; }              // Number of Gift Cards and value of each
+        public int CardsQuantity { get; set; }              // Number of PEX Cards and value of each
         public decimal CardsValueEach { get; set; }
 
 
@@ -526,7 +528,7 @@ namespace Portal11.Models
 
         public DateTime DateOfInvoice { get; set; }         // Date Invoice was received
 
-        public DateTime DateNeeded { get; set; }            // Date needed for Gift Cards
+        public DateTime DateNeeded { get; set; }            // Date needed for PEX Cards
 
         [StringLength(250), DataType(DataType.MultilineText)]
         public string DeliveryAddress { get; set; }         // Delivery Instructions, special for Purchase Order
@@ -563,7 +565,7 @@ namespace Portal11.Models
         public int? PersonID { get; set; }
         public virtual Person Person { get; set; }
 
-        public YesNo POVendorMode { get; set; }              // PO Fulfilment Instructions
+        public YesNo POVendorMode { get; set; }             // PO Fulfilment Instructions
 
         [Required]
         public int? ProjectID { get; set; }                 // The Project that owns this Request
@@ -572,7 +574,9 @@ namespace Portal11.Models
         [DataType(DataType.MultilineText)]
         public string ReturnNote { get; set; }              // When approval is denied, the reason goes here
 
-        public SourceOfExpFunds SourceOfFunds { get; set; }    // Where the Request gets its Funds
+        public bool Rush { get; set; }                      // Whether the Request has "Rush" status
+
+        public SourceOfExpFunds SourceOfFunds { get; set; } // Where the Request gets its Funds
         public int? ProjectClassID { get; set; }
         public virtual ProjectClass ProjectClass { get; set; }
 
@@ -630,7 +634,7 @@ namespace Portal11.Models
         Approved,
         [Description("Payment Sent")]
         PaymentSent,
-        [Description("Paid")]
+        [Description("Paid and Sent")]
         Paid,
         [Description("Returned")]
         Returned,
@@ -644,8 +648,8 @@ namespace Portal11.Models
     {
         [Description("Contractor Invoice")]
         ContractorInvoice = 1,
-        [Description("Gift Card")]
-        GiftCard,
+        [Description("PEX Card")]
+        PEXCard,
         [Description("Paycheck")]
         Paycheck,
         [Description("Purchase Order")]
@@ -681,12 +685,13 @@ namespace Portal11.Models
     public class GLCode
     {
         public int GLCodeID { get; set; }
-        [Required]
+        [Required, StringLength(20), Index("FranchiseAndGLCode", 1)]
         public string FranchiseKey { get; set; }
         public bool Inactive { get; set; }
+        public const int InactiveColumn = 5;                // Column when displayed in GridView
         public bool ExpCode { get; set; }
         public bool DepCode { get; set; }
-        [Required]
+        [Required, StringLength(100), Index("FranchiseAndGLCode", 2, IsUnique = true)]
         public string Code { get; set; }
         public string Description { get; set; }
         [Required]
@@ -734,10 +739,11 @@ namespace Portal11.Models
     public class Person
     {
         public int PersonID { get; set; }
-        [Required]
+        [Required, StringLength(20), Index("FranchiseAndPerson", 1)]
         public string FranchiseKey { get; set; }
         public bool Inactive { get; set; }
-        [Required, StringLength(100)]
+        public const int InactiveColumn = 4;                // Column when displayed in GridView
+        [Required, StringLength(100), Index("FranchiseAndPerson", 2, IsUnique = true)]
         public string Name { get; set; }
         [StringLength(250), DataType(DataType.MultilineText)]
         public string Address { get; set; }
@@ -788,11 +794,16 @@ namespace Portal11.Models
     public class Project
     {
         public int ProjectID { get; set; }
-        [Required]
+        [Required, StringLength(20), Index("FranchiseAndProject", 1)
+        //    , Index("FranchiseAndProjectCode",1)
+            ]
         public string FranchiseKey { get; set; }
         public bool Inactive { get; set; }
-        [Required, StringLength(100)]
+        [Required, StringLength(100), Index("FranchiseAndProject", 2, IsUnique = true)]
         public string Name { get; set; }
+        [StringLength(3)]
+        //[Required, StringLength(3), Index("FranchiseAndProjectCode", 2, IsUnique = true)]
+        public string Code { get; set; }
         [DataType(DataType.MultilineText)]
         public string Description { get; set; }
         [Required]
@@ -808,6 +819,7 @@ namespace Portal11.Models
         public int ProjectClassID { get; set; }
         [Required]
         public bool Inactive { get; set; }
+        public const int InactiveColumn = 5;                // Column when displayed in GridView
         [Required]
         public int ProjectID { get; set; }
         [Required, StringLength(100)]
@@ -824,10 +836,10 @@ namespace Portal11.Models
     public class ProjectClassMaster
     {
         public int ProjectClassMasterID { get; set; }
-        [Required]
+        [Required, StringLength(20), Index("FranchiseAndPCM", 1)]
         public string FranchiseKey { get; set; }
         public bool Inactive { get; set; }
-        [Required, StringLength(100)]
+        [Required, StringLength(100), Index("FranchiseAndPCM", 2, IsUnique = true)]
         public string Name { get; set; }
         [DataType(DataType.MultilineText)]
         public string Description { get; set; }
@@ -1202,7 +1214,7 @@ namespace Portal11.Models
 
             CStaffExpVisible = "StaffExpVisible",
             CStaffCkEContractorInvoice = "CkEContractorInvoice",
-            CStaffCkEGiftCard = "CkEGiftCard",
+            CStaffCkEPEXCard = "CkEPEXCard",
             CStaffCkEPaycheck = "CkEPaycheck",
             CStaffCkEPurchaseOrder = "CkEPurchaseOrder",
             CStaffCkEReimbursement = "CkEReimbursement",

--- a/Portal11/Portal11.csproj
+++ b/Portal11/Portal11.csproj
@@ -536,6 +536,7 @@
     <Compile Include="Logic\CookieActions.cs" />
     <Compile Include="Logic\DateActions.cs" />
     <Compile Include="Logic\EnumActions.cs" />
+    <Compile Include="Logic\ExceptionActions.cs" />
     <Compile Include="Logic\ProjectClassActions.cs" />
     <Compile Include="Logic\QueryStringActions.cs" />
     <Compile Include="Logic\SupportingActions.cs">

--- a/Portal11/Proj/EditProjectClass.aspx.cs
+++ b/Portal11/Proj/EditProjectClass.aspx.cs
@@ -1,4 +1,5 @@
 ﻿using Portal11.ErrorLog;
+using Portal11.Logic;
 using Portal11.Models;
 using System;
 using System.Collections.Generic;
@@ -117,6 +118,11 @@ namespace Portal11.Proj
                 }
                 catch (Exception ex)
                 {
+                    if (ExceptionActions.IsDuplicateKeyException(ex))       // If true this is a Duplicate Key exception
+                    {
+                        litDangerMessage.Text = $"Another Project Class with the name '{txtName.Text}' already exists on this Project. Project Classes must be unique.";
+                        return;                                             // Report the error to user and try again
+                    }
                     LogError.LogDatabaseError(ex, "EditProjectClass", "Error writing ProjectClass row"); // Fatal error
                 }
             }

--- a/Portal11/Proj/ProjectDashboard.aspx
+++ b/Portal11/Proj/ProjectDashboard.aspx
@@ -13,14 +13,12 @@
         <div class="col-md-4 col-xs-6">
             <h2><%: Title %></h2>
         </div>
-        <div class="panel panel-default col-md-offset-4 col-md-4 col-xs-6">
-            <h4>Balance as of:&nbsp;<asp:Literal ID="litBalance" runat="server"></asp:Literal>
-            </h4>
-
-            <div class="row">
-                <div class="col-xs-offset-1 col-xs-11">
-                    Current Funds:&nbsp;<asp:Literal ID="litCurrentFunds" runat="server" >$xxx,xxx.xx</asp:Literal>
-                </div>
+        <div class="text-right col-md-offset-4 col-md-4 col-xs-6">
+            <div class="col-xs-12">
+                <h4>Balance as of:&nbsp;<asp:Literal ID="litBalance" runat="server"></asp:Literal></h4>
+            </div>
+            <div class="col-xs-12">
+                <h4>Current Funds:&nbsp;<asp:Literal ID="litCurrentFunds" runat="server" >$xxx,xxx.xx</asp:Literal></h4>
             </div>
         </div>
     </div>
@@ -60,7 +58,7 @@
                     <div class="checkbox">
                         <asp:CheckBox ID="ckRAwaitingProjectStaff" runat="server" Text="Awaiting Project Staff" CssClass="col-xs-12" Checked="true"
                             OnCheckedChanged="SearchCriteriaChanged" AutoPostBack="true" />
-                        <asp:CheckBox ID="ckRAwaitingCWStaff" runat="server" Text="Awaiting CW Staff" CssClass="col-xs-12"
+                        <asp:CheckBox ID="ckRAwaitingCWStaff" runat="server" Text="Awaiting CW Staff" CssClass="col-xs-12" Checked="true"
                             OnCheckedChanged="SearchCriteriaChanged" AutoPostBack="true" />
                         <asp:CheckBox ID="ckRApproved" runat="server" Text="Approved/Complete/Paid" CssClass="col-xs-12" Checked="true"
                             OnCheckedChanged="SearchCriteriaChanged" AutoPostBack="true" />

--- a/Portal11/Properties/AssemblyInfo.cs
+++ b/Portal11/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 //
 // You can specify all the values or you can default the Revision and Build Numbers 
 // by using the '*' as shown below:
-[assembly: AssemblyVersion("0.7.*")]
+[assembly: AssemblyVersion("1.1.*")]
 [assembly: AssemblyFileVersion("1.0.0.0")]

--- a/Portal11/Rqsts/EditExpense.aspx
+++ b/Portal11/Rqsts/EditExpense.aspx
@@ -35,7 +35,7 @@
                             <asp:ListItem Text="Reimbursement" Value="Reimbursement"></asp:ListItem>
                             <asp:ListItem Text="Vendor Invoice" Value="VendorInvoice"></asp:ListItem>
                             <asp:ListItem Text="Purchase Order" Value="PurchaseOrder"></asp:ListItem>
-                            <asp:ListItem Text="Gift Card" Value="GiftCard"></asp:ListItem>
+                            <asp:ListItem Text="PEX Card" Value="PEXCard"></asp:ListItem>
                         </asp:RadioButtonList>
                     </div>
                 </div>

--- a/Portal11/Rqsts/EditExpense.aspx.cs
+++ b/Portal11/Rqsts/EditExpense.aspx.cs
@@ -766,7 +766,7 @@ namespace Portal11.Rqsts
                         litSupportingDocMin.Text = "1";
                         break;
                     }
-                case ExpType.GiftCard:
+                case ExpType.PEXCard:
                     {
                         lblAmount.Text = "Total Amount";
                         pnlBeginningEnding.Visible = false;

--- a/Portal11/Rqsts/ReviewApproval.aspx
+++ b/Portal11/Rqsts/ReviewApproval.aspx
@@ -125,7 +125,7 @@
                 <div class="row">
                     <asp:Label runat="server" CssClass="col-sm-2 col-xs-12 control-label">Notes</asp:Label>
                     <div class="col-lg-3 col-md-4 col-sm-5 col-xs-6">
-                        <asp:TextBox ID="txtNotes" runat="server" CssClass="form-control has-success" ReadOnly="true"></asp:TextBox>
+                        <asp:TextBox ID="txtNotes" runat="server" CssClass="form-control has-success" TextMode="MultiLine" ReadOnly="true"></asp:TextBox>
                     </div>
                 </div>
             </div>

--- a/Portal11/Rqsts/ReviewApproval.aspx.cs
+++ b/Portal11/Rqsts/ReviewApproval.aspx.cs
@@ -118,8 +118,9 @@ namespace Portal11.Rqsts
         {
             SaveApp(AppState.Returned, "Returned");                 // Update App; write new History row
             //TODO: Notify the Project Director
-            Response.Redirect(PortalConstants.URLStaffDashboard + "?" + PortalConstants.QSSeverity + "=" + PortalConstants.QSSuccess + "&"
-                                  + PortalConstants.QSStatus + "=" + "Request returned to Project Direcctor");
+            Response.Redirect(litSavedReturn.Text + "?"
+                                + PortalConstants.QSSeverity + "=" + PortalConstants.QSSuccess + "&"
+                                + PortalConstants.QSStatus + "=" + "Request returned to Project Direcctor");
         }
 
         // User pressed History button. Fetch all the AppHistory rows for this App and fill a GridView.

--- a/Portal11/Rqsts/ReviewDeposit.aspx
+++ b/Portal11/Rqsts/ReviewDeposit.aspx
@@ -236,7 +236,7 @@
                 <div class="row">
                     <asp:Label runat="server" CssClass="col-sm-2 col-xs-12 control-label">Notes</asp:Label>
                     <div class="col-lg-3 col-md-4 col-sm-5 col-xs-6">
-                        <asp:TextBox ID="txtNotes" runat="server" CssClass="form-control has-success" ReadOnly="true"></asp:TextBox>
+                        <asp:TextBox ID="txtNotes" runat="server" CssClass="form-control has-success" TextMode="MultiLine" ReadOnly="true"></asp:TextBox>
                     </div>
                 </div>
             </div>

--- a/Portal11/Rqsts/ReviewDeposit.aspx.cs
+++ b/Portal11/Rqsts/ReviewDeposit.aspx.cs
@@ -110,8 +110,9 @@ namespace Portal11.Rqsts
         {
             SaveDep(DepState.Returned, "Returned");                 // Update Dep; write new History row
             //TODO: Notify the Project Director
-            Response.Redirect(PortalConstants.URLStaffDashboard + "?" + PortalConstants.QSSeverity + "=" + PortalConstants.QSSuccess + "&"
-                                  + PortalConstants.QSStatus + "=" + "Request returned to Project Direcctor");
+            Response.Redirect(litSavedReturn.Text + "?"
+                                + PortalConstants.QSSeverity + "=" + PortalConstants.QSSuccess + "&"
+                                + PortalConstants.QSStatus + "=" + "Request returned to Project Direcctor");
         }
 
         // User pressed History button. Fetch all the DepHistory rows for this Dep and fill a GridView.

--- a/Portal11/Rqsts/ReviewExpense.aspx
+++ b/Portal11/Rqsts/ReviewExpense.aspx
@@ -389,7 +389,7 @@
                 <div class="row">
                     <asp:Label runat="server" CssClass="col-sm-2 col-xs-12 control-label">Notes</asp:Label>
                     <div class="col-lg-3 col-md-4 col-sm-5 col-xs-6">
-                        <asp:TextBox ID="txtNotes" runat="server" CssClass="form-control has-success" ReadOnly="true"></asp:TextBox>
+                        <asp:TextBox ID="txtNotes" runat="server" CssClass="form-control has-success" TextMode="MultiLine" ReadOnly="true"></asp:TextBox>
                     </div>
                 </div>
             </div>

--- a/Portal11/Rqsts/ReviewExpense.aspx.cs
+++ b/Portal11/Rqsts/ReviewExpense.aspx.cs
@@ -114,8 +114,9 @@ namespace Portal11.Rqsts
         {
             SaveExp(ExpState.Returned, "Returned");                 // Update Exp; write new History row
             //TODO: Notify the Project Director
-            Response.Redirect(PortalConstants.URLStaffDashboard + "?" + PortalConstants.QSSeverity + "=" + PortalConstants.QSSuccess + "&"
-                                  + PortalConstants.QSStatus + "=" + "Request returned to Project Direcctor");
+            Response.Redirect(litSavedReturn.Text + "?"
+                                + PortalConstants.QSSeverity + "=" + PortalConstants.QSSuccess + "&"
+                                + PortalConstants.QSStatus + "=" + "Request Returned to Project");
         }
 
         // User pressed History button. Fetch all the ExpHistory rows for this Exp and fill a GridView.
@@ -189,7 +190,7 @@ namespace Portal11.Rqsts
                         pnlPOFulfillmentInstructions.Visible = false;
                         break;
                     }
-                case ExpType.GiftCard:
+                case ExpType.PEXCard:
                     {
                         lblAmount.Text = "Total Amount";
                         pnlBeginningEnding.Visible = false;

--- a/Portal11/Select/SelectEntity.aspx
+++ b/Portal11/Select/SelectEntity.aspx
@@ -100,8 +100,12 @@
                                 <asp:Label ID="lblEmail" runat="server" Text='<%# Eval("Email").ToString().TrimString(40) %>' />
                             </ItemTemplate>
                         </asp:TemplateField>
-                        <asp:BoundField DataField="Inactive" HeaderText="Inactive" />
-                    </Columns>
+                       <asp:TemplateField HeaderText="Inactive">
+                            <ItemTemplate>
+                                <asp:Label ID="lblInactive" runat="server" Text='<%# Bind("Inactive") %>'></asp:Label>
+                            </ItemTemplate>
+                        </asp:TemplateField>
+                     </Columns>
                 </asp:GridView>
 
             </div>

--- a/Portal11/Select/SelectEntity.aspx.cs
+++ b/Portal11/Select/SelectEntity.aspx.cs
@@ -37,6 +37,7 @@ namespace Portal11.Select
                     LogError.LogQueryStringError("SelectEntity", "Missing Query String 'Command'"); // Log fatal error
                 litSavedCommand.Text = cmd;                                 // Remember the command that invoked this page
 
+                AllEntityView.PageSize = CookieActions.FindGridViewRows();  // Find number of rows per page from cookie
                 LoadEntityView();                                           // Fill the grid
             }
         }
@@ -57,6 +58,9 @@ namespace Portal11.Select
                 e.Row.ToolTip = "Click to select this Entity";            // Establish tool tip during flyover
                 e.Row.Attributes["onclick"] = this.Page.ClientScript.GetPostBackClientHyperlink(this.AllEntityView, "Select$" + e.Row.RowIndex);
                 // Mark the row "Selected" on a click. That will fire SelectedIndexChanged
+
+                Label inactiveLabel = (Label)e.Row.FindControl("lblInactive");
+                inactiveLabel.Visible = true;                               // Make sure the Inactive column appears if hidden earlier
             }
             return;
         }
@@ -102,8 +106,7 @@ namespace Portal11.Select
             Label name = (Label)AllEntityView.SelectedRow.Cells[1].FindControl("lblName"); // Find the label control that contains Entity Name
             string entityID = entID.Text;                                   // Extract the text of the control, which is EntityID as a string
             if (entityID == "")
-                LogError.LogQueryStringError("SelectEntity", string.Format(
-                    "EntityID '{0}' from selected GridView row is missing", entityID)); // Log fatal error
+                LogError.LogQueryStringError("SelectEntity", $"EntityID '{entityID}' from selected GridView row is missing"); // Log fatal error
 
             Response.Redirect(PortalConstants.URLEditEntity + "?" + PortalConstants.QSEntityID + "=" + entityID + "&" +
                                             PortalConstants.QSEntityName + "=" + name.Text + "&" +
@@ -139,6 +142,10 @@ namespace Portal11.Select
                 List<Entity> ents = context.Entitys.AsExpandable().Where(pred).OrderBy(p => p.Name).ToList(); // Query, sort and make list
                 AllEntityView.DataSource = ents;                        // Give it to the GridView control
                 AllEntityView.DataBind();                               // And display it
+
+                // As a flourish, if the "Include Inactive" checkbox is not checked, do not display the Inactive column
+
+                AllEntityView.Columns[Entity.InactiveColumn].Visible = chkInactive.Checked; // If checked, column is visible
 
                 NavigationActions.EnableGridViewNavButtons(AllEntityView); // Enable appropriate nav buttons based on page count
             }

--- a/Portal11/Select/SelectGLCode.aspx
+++ b/Portal11/Select/SelectGLCode.aspx
@@ -97,10 +97,14 @@
                         </asp:TemplateField>
                         <asp:BoundField DataField="Code" HeaderText="Code" />
                         <asp:BoundField DataField="Description" HeaderText="Description" />
-                        <asp:BoundField DataField="Inactive" HeaderText="Inactive" ItemStyle-Width="8"/>
                         <asp:BoundField DataField="DepCode" HeaderText="Deposit" ItemStyle-Width="8"/>
                         <asp:BoundField DataField="ExpCode" HeaderText="Expense" ItemStyle-Width="8"/>
-                    </Columns>
+                        <asp:TemplateField HeaderText="Inactive">
+                            <ItemTemplate>
+                                <asp:Label ID="lblInactive" runat="server" Text='<%# Bind("Inactive") %>'></asp:Label>
+                            </ItemTemplate>
+                        </asp:TemplateField>
+                     </Columns>
                 </asp:GridView>
 
             </div>

--- a/Portal11/Select/SelectGLCode.aspx.cs
+++ b/Portal11/Select/SelectGLCode.aspx.cs
@@ -30,11 +30,12 @@ namespace Portal11.Select
 
                 string cmd = Request.QueryString[PortalConstants.QSCommand];  // Look on the query string that invoked this page. Find the command.
 
-                if (cmd == "")                                            // If == no command. We are invoked incorrectly.
+                if (cmd == "")                                              // If == no command. We are invoked incorrectly.
                     LogError.LogQueryStringError("SelectGLCode", "Missing Query String 'Command'"); // Log fatal error
 
-                litSavedCommand.Text = cmd;                               // Remember the command that invoked this page
-                LoadGLCodeView();                                          // Fill the grid
+                litSavedCommand.Text = cmd;                                 // Remember the command that invoked this page
+                GLCodeView.PageSize = CookieActions.FindGridViewRows();     // Find number of rows per page from cookie
+                LoadGLCodeView();                                           // Fill the grid
             }
         }
 
@@ -54,6 +55,9 @@ namespace Portal11.Select
                 e.Row.ToolTip = "Click to select this GLCode";            // Establish tool tip during flyover
                 e.Row.Attributes["onclick"] = this.Page.ClientScript.GetPostBackClientHyperlink(this.GLCodeView, "Select$" + e.Row.RowIndex);
                 // Mark the row "Selected" on a click. That will fire SelectedIndexChanged
+
+                Label inactiveLabel = (Label)e.Row.FindControl("lblInactive");
+                inactiveLabel.Visible = true;                               // Make sure the Inactive column appears if hidden earlier
             }
             return;
         }
@@ -137,6 +141,10 @@ namespace Portal11.Select
                 List<GLCode> codes = context.GLCodes.AsExpandable().Where(pred).OrderBy(p => p.Code).ToList(); // Query, sort and make list
                 GLCodeView.DataSource = codes;                         // Give it to the GridView control
                 GLCodeView.DataBind();                                 // And display it
+
+                // As a flourish, if the "Include Inactive" checkbox is not checked, do not display the Inactive column
+
+                GLCodeView.Columns[GLCode.InactiveColumn].Visible = chkInactive.Checked; // If checked, column is visible
 
                 NavigationActions.EnableGridViewNavButtons(GLCodeView); // Enable appropriate nav buttons based on page count
             }

--- a/Portal11/Select/SelectPerson.aspx
+++ b/Portal11/Select/SelectPerson.aspx
@@ -91,7 +91,11 @@
                         <asp:BoundField DataField="Name" HeaderText="Name" />
                         <asp:BoundField DataField="Email" HeaderText="Email" />
                         <asp:BoundField DataField="W9Present" HeaderText="W-9 Present" />
-                        <asp:BoundField DataField="Inactive" HeaderText="Inactive" />
+                        <asp:TemplateField HeaderText="Inactive">
+                            <ItemTemplate>
+                                <asp:Label ID="lblInactive" runat="server" Text='<%# Bind("Inactive") %>'></asp:Label>
+                            </ItemTemplate>
+                        </asp:TemplateField>
                     </Columns>
                 </asp:GridView>
 

--- a/Portal11/Select/SelectPerson.aspx.cs
+++ b/Portal11/Select/SelectPerson.aspx.cs
@@ -35,7 +35,8 @@ namespace Portal11.Select
                     LogError.LogQueryStringError("SelectPerson", "Missing Query String 'Command'"); // Log fatal error
 
                 litSavedCommand.Text = cmd;                                 // Remember the command that invoked this page
-                LoadPersonView();                                         // Fill the grid
+                PersonView.PageSize = CookieActions.FindGridViewRows();     // Find number of rows per page from cookie
+                LoadPersonView();                                           // Fill the grid
             }
         }
 
@@ -55,6 +56,9 @@ namespace Portal11.Select
                 e.Row.ToolTip = "Click to select this Person";            // Establish tool tip during flyover
                 e.Row.Attributes["onclick"] = this.Page.ClientScript.GetPostBackClientHyperlink(this.PersonView, "Select$" + e.Row.RowIndex);
                 // Mark the row "Selected" on a click. That will fire SelectedIndexChanged
+
+                Label inactiveLabel = (Label)e.Row.FindControl("lblInactive");
+                inactiveLabel.Visible = true;                               // Make sure the Inactive column appears if hidden earlier
             }
             return;
         }
@@ -134,6 +138,9 @@ namespace Portal11.Select
                 PersonView.DataSource = persons;                        // Give it to the GridView control
                 PersonView.DataBind();                                  // And display it
 
+                // As a flourish, if the "Include Inactive" checkbox is not checked, do not display the Inactive column
+
+                PersonView.Columns[Person.InactiveColumn].Visible = chkInactive.Checked; // If checked, column is visible
                 NavigationActions.EnableGridViewNavButtons(PersonView); // Enable appropriate nav buttons based on page count
             }
         }

--- a/Portal11/Select/SelectProject.aspx.cs
+++ b/Portal11/Select/SelectProject.aspx.cs
@@ -75,6 +75,8 @@ namespace Portal11.Staff
                 if (cmd == PortalConstants.QSCommandEdit)                   // If == we are selecting a Project to edit
                     btnNew.Enabled = true;                                  // Offer the opportunity to create a new Project
 
+                AllProjectView.PageSize = CookieActions.FindGridViewRows();  // Find number of rows per page from cookie
+                UserProjectView.PageSize = CookieActions.FindGridViewRows();  // Find number of rows per page from cookie
                 LoadProjectView();                                          // Fill the grid
             }
         }

--- a/Portal11/Select/SelectProjectClass.aspx
+++ b/Portal11/Select/SelectProjectClass.aspx
@@ -92,7 +92,11 @@
                         <asp:BoundField DataField="Description" HeaderText="Description" />
                         <asp:BoundField DataField="CreatedFromMaster" HeaderText="From Master" />
                         <asp:BoundField DataField="Default" HeaderText="Default" />
-                        <asp:BoundField DataField="Inactive" HeaderText="Inactive" />
+                       <asp:TemplateField HeaderText="Inactive">
+                            <ItemTemplate>
+                                <asp:Label ID="lblInactive" runat="server" Text='<%# Bind("Inactive") %>'></asp:Label>
+                            </ItemTemplate>
+                        </asp:TemplateField>
                     </Columns>
                 </asp:GridView>
 

--- a/Portal11/Select/SelectProjectClass.aspx.cs
+++ b/Portal11/Select/SelectProjectClass.aspx.cs
@@ -34,6 +34,7 @@ namespace Portal11.Select
                 //    LogError.LogQueryStringError("EditProjectClasses", "Missing Query String 'Command'"); // Log fatal error
 
                 litSavedCommand.Text = PortalConstants.QSCommandEdit;       // Always Edit, at least for now
+                ProjectClassView.PageSize = CookieActions.FindGridViewRows();  // Find number of rows per page from cookie
                 LoadProjectClassView();                                     // Fill the grid
             }
         }
@@ -54,6 +55,9 @@ namespace Portal11.Select
                 e.Row.ToolTip = "Click to select this Project Class";       // Establish tool tip during flyover
                 e.Row.Attributes["onclick"] = this.Page.ClientScript.GetPostBackClientHyperlink(this.ProjectClassView, "Select$" + e.Row.RowIndex);
                 // Mark the row "Selected" on a click. That will fire SelectedIndexChanged
+
+                Label inactiveLabel = (Label)e.Row.FindControl("lblInactive");
+                inactiveLabel.Visible = true;                               // Make sure the Inactive column appears if hidden earlier
             }
             return;
         }
@@ -139,6 +143,10 @@ namespace Portal11.Select
                 List<ProjectClass> projs = context.ProjectClasses.AsExpandable().Where(pred).OrderBy(p => p.Name).ToList(); // Query, sort and make list
                 ProjectClassView.DataSource = projs;                        // Give it to the GridView control
                 ProjectClassView.DataBind();                                // And display it
+
+                // As a flourish, if the "Include Inactive" checkbox is not checked, do not display the Inactive column
+
+                ProjectClassView.Columns[ProjectClass.InactiveColumn].Visible = chkInactive.Checked; // If checked, column is visible
 
                 NavigationActions.EnableGridViewNavButtons(ProjectClassView); // Enable appropriate nav buttons based on page count
             }

--- a/Portal11/Select/SelectUser.aspx
+++ b/Portal11/Select/SelectUser.aspx
@@ -95,6 +95,11 @@
                             </ItemTemplate>
                         </asp:TemplateField>
                         <asp:BoundField DataField="Email" HeaderText="Email" />
+                        <asp:TemplateField HeaderText="Inactive">
+                            <ItemTemplate>
+                                <asp:Label ID="lblInactive" runat="server" Text='<%# Bind("Inactive") %>'></asp:Label>
+                            </ItemTemplate>
+                        </asp:TemplateField>
                     </Columns>
                 </asp:GridView>
 

--- a/Portal11/Select/SelectUser.aspx.cs
+++ b/Portal11/Select/SelectUser.aspx.cs
@@ -36,6 +36,7 @@ namespace Portal11.Admin
                     LogError.LogQueryStringError("SelectUser", "Missing Query String 'Command'"); // Log fatal error
 
                 litSavedCommand.Text = cmd;                             // Remember the command that invoked this page
+                UserView.PageSize = CookieActions.FindGridViewRows();   // Find number of rows per page from cookie
                 LoadUserView();                                         // Fill the grid
             }
         }
@@ -56,6 +57,9 @@ namespace Portal11.Admin
                 e.Row.ToolTip = "Click to select this User";            // Establish tool tip during flyover
                 e.Row.Attributes["onclick"] = this.Page.ClientScript.GetPostBackClientHyperlink(this.UserView, "Select$" + e.Row.RowIndex);
                 // Mark the row "Selected" on a click. That will fire SelectedIndexChanged
+
+                Label inactiveLabel = (Label)e.Row.FindControl("lblInactive");
+                inactiveLabel.Visible = true;                               // Make sure the Inactive column appears if hidden earlier
             }
             return;
         }
@@ -162,6 +166,10 @@ namespace Portal11.Admin
                 List<ApplicationUser> users = context.Users.AsExpandable().Where(pred).OrderBy(p => p.FullName).ToList(); // Query, sort and make list
                 UserView.DataSource = users;                            // Give it to the GridView control
                 UserView.DataBind();                                    // And display it
+
+                // As a flourish, if the "Include Inactive" checkbox is not checked, do not display the Inactive column
+
+                UserView.Columns[ApplicationUser.InactiveColumn].Visible = chkInactive.Checked; // If checked, column is visible
 
                 NavigationActions.EnableGridViewNavButtons(UserView);   // Enable appropriate nav buttons based on page count
             }

--- a/Portal11/Select/SelectVendor.aspx.cs
+++ b/Portal11/Select/SelectVendor.aspx.cs
@@ -36,6 +36,7 @@ namespace Portal11.Select
                     LogError.LogQueryStringError("SelectVendor", "Missing Query String 'Command'"); // Log fatal error
                 litSavedCommand.Text = cmd;                                 // Remember the command that invoked this page
 
+                AllVendorView.PageSize = CookieActions.FindGridViewRows();  // Find number of rows per page from cookie
                 LoadVendorView();                                           // Fill the grid
             }
         }

--- a/Portal11/Site.Master
+++ b/Portal11/Site.Master
@@ -66,7 +66,7 @@
                             <ul class="dropdown-menu" role="menu">
                                 <li><a runat="server" href="~/Select/SelectProject?Command=Menu">Select Project</a></li>
 <%--                                <li><a runat="server" href="~/Proj/AssignPersons" >Assign Persons to Project</a></li>--%>
-                                <li><a runat="server" href="~/Select/SelectProjectClass?Command=Edit">Edit Project Classes</a></li>
+                                <li><a id="mnuEditProjectClasses" runat="server" href="~/Select/SelectProjectClass?Command=Edit">Edit Project Classes</a></li>
                             </ul>
                         </li>
 
@@ -96,7 +96,7 @@
                         </LoggedInTemplate>
                     </asp:LoginView>
                     <ul class="nav navbar-nav navbar-right">
-                        <li><a runat="server" href="#">
+                        <li><a runat="server">
                             <asp:Label runat="server" ID="labFullName" /></a></li>
                         <li><a runat="server" id="mnuNoProjectRole" href="#" visible="false">
                             <asp:Literal runat="server" ID="litNoProjectRole" /></a></li>

--- a/Portal11/Site.Master.cs
+++ b/Portal11/Site.Master.cs
@@ -83,7 +83,7 @@ namespace Portal11
                     //  1) Display their Full Name
 
                     labFullName.Text = userInfoCookie[PortalConstants.CUserFullName]; //Load label with user's full name from cookie
-                    labFullName.ToolTip = "This is a test";
+                    labFullName.ToolTip = "Not associated with a specific project";
 
                     //  2) If the User has Admin powers - regardless of role - turn on the Admin menu
 
@@ -122,6 +122,7 @@ namespace Portal11
                             {
                                 litNoProjectRole.Text = userInfoCookie[PortalConstants.CUserRoleDescription]; // No project available. Use "base" role
                                 mnuNoProjectRole.Visible = true;                    // Make menu visible in Navbar; it doesn't link anywhere
+                                mnuEditProjectClasses.Visible = false;              // Doesn't work without a project selected, so turn it off
                             }
                             break;
                         }

--- a/Portal11/Site.Master.designer.cs
+++ b/Portal11/Site.Master.designer.cs
@@ -58,6 +58,15 @@ namespace Portal11 {
         protected global::System.Web.UI.HtmlControls.HtmlAnchor mnuProject;
         
         /// <summary>
+        /// mnuEditProjectClasses control.
+        /// </summary>
+        /// <remarks>
+        /// Auto-generated field.
+        /// To modify move field declaration from designer file to code-behind file.
+        /// </remarks>
+        protected global::System.Web.UI.HtmlControls.HtmlAnchor mnuEditProjectClasses;
+        
+        /// <summary>
         /// mnuUser control.
         /// </summary>
         /// <remarks>

--- a/Portal11/Staff/StaffDashboard.aspx
+++ b/Portal11/Staff/StaffDashboard.aspx
@@ -492,7 +492,7 @@
                             OnCheckedChanged="SearchCriteriaChanged" AutoPostBack="true" />
                         <asp:CheckBox ID="ckEReimbursement" runat="server" Text="Reimbursement" CssClass="col-xs-6" Checked="true"
                             OnCheckedChanged="SearchCriteriaChanged" AutoPostBack="true" />
-                        <asp:CheckBox ID="ckEGiftCard" runat="server" Text="Gift Card" CssClass="col-xs-6" Checked="true"
+                        <asp:CheckBox ID="ckEPEXCard" runat="server" Text="PEX Card" CssClass="col-xs-6" Checked="true"
                             OnCheckedChanged="SearchCriteriaChanged" AutoPostBack="true" />
                     </div>
                     </div>

--- a/Portal11/Staff/StaffDashboard.aspx.designer.cs
+++ b/Portal11/Staff/StaffDashboard.aspx.designer.cs
@@ -445,13 +445,13 @@ namespace Portal11.Rqsts {
         protected global::System.Web.UI.WebControls.CheckBox ckEReimbursement;
         
         /// <summary>
-        /// ckEGiftCard control.
+        /// ckEPEXCard control.
         /// </summary>
         /// <remarks>
         /// Auto-generated field.
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
-        protected global::System.Web.UI.WebControls.CheckBox ckEGiftCard;
+        protected global::System.Web.UI.WebControls.CheckBox ckEPEXCard;
         
         /// <summary>
         /// StaffExpView control.


### PR DESCRIPTION
For Entities, GL Codes, Persons, and Projects, the Portal now requires that names be unique. That is, duplicate names are not allowed.
In all Grids, the number of rows per page is now controlled by a user-specific parameter. This can be adjusted on the Edit Portal User page.
On Edit Project, the Balance Date can now be edited.
In Project Dashboard and Staff Dashboard, a bug in pagination of request lists is fixed.
A bug that prevented Staff from Reviewing Approvals is fixed.
In Project Dashboard, a Project Director can now archive a Deposit Request.
A Gift Card is now called a PEX Card.