### PR TITLE
Changes since 1-1

### DIFF
--- a/Portal11/Admin/EditProject.aspx
+++ b/Portal11/Admin/EditProject.aspx
@@ -41,6 +41,23 @@
             </div>
         </asp:Panel>
 
+        <asp:Panel ID="pnlCode" runat="server">
+            <div class="form-group">
+                <div class="row">
+                    <asp:Label runat="server" AssociatedControlID="txtCode" CssClass="col-sm-2 col-xs-12 control-label" Font-Bold="true">Project Code</asp:Label>
+                    <div class="col-lg-4 col-md-4 col-xs-6">
+                        <asp:TextBox runat="server" ID="txtCode" CssClass="form-control has-success"></asp:TextBox>
+                    </div>
+                    <div class="col-lg-6 col-md-6 col-xs-6">
+                        <asp:RequiredFieldValidator runat="server" ControlToValidate="txtCode"
+                            CssClass="text-danger" ErrorMessage="Please supply a Project Code." />
+                        <asp:RegularExpressionValidator runat="server" ControlToValidate="txtCode" ValidationExpression="[\S\d]{3}"
+                            CssClass="text-danger" ErrorMessage="Project Code must be exactly three characters in length." />
+                    </div>
+                </div>
+            </div>
+        </asp:Panel>
+
         <asp:Panel ID="pnlDescription" runat="server">
             <div class="form-group">
                 <div class="row">

--- a/Portal11/Admin/EditProject.aspx.cs
+++ b/Portal11/Admin/EditProject.aspx.cs
@@ -136,17 +136,6 @@ namespace Portal11.Admin
                     if (litSavedProjectID.Text != "") projectID = Convert.ToInt32(litSavedProjectID.Text); // If != saved ID is available, use it  
                     if (projectID == 0)                                         // If == no doubt about it, Save makes a new row
                     {
-
-                        //// Make sure the Name is unique in this Franchise
-
-                        //int matchingNames = context.Projects.Where(p => (p.FranchiseKey == fran) && (p.Name == txtName.Text)).Count();
-                        //// Look for existing row match
-                        //if (matchingNames != 0)                                 // If != a Project with this Name value already exists in database
-                        //{
-                        //    Response.Redirect(PortalConstants.URLAdminMain + "?" + PortalConstants.QSSeverity + "=" + PortalConstants.QSDanger + "&"
-                        //                        + PortalConstants.QSStatus + "=That Project Name already exists. You can edit it.", false); // Back to the barn
-                        //    return;
-                        //}
                         Project toSave = new Project();                             // Get a place to hold everything
                         toSave.CreatedTime = System.DateTime.Now;                   // Stamp time when Request was first created as "now"
                         UnloadPanels(toSave);                                       // Move from Panels to record
@@ -185,11 +174,10 @@ namespace Portal11.Admin
         {
             txtName.Text = record.Name;
             chkInact.Checked = record.Inactive;
+            txtCode.Text = record.Code;
             txtDescription.Text = record.Description;
             txtBalanceDate.Text = record.BalanceDate.Date.ToShortDateString();
             txtCurrentFunds.Text = record.CurrentFunds.ToString("C");
-            //decimal total = StateActions.LoadGrantsList(record.ProjectID, lstRestrictedGrants); // Fill read-only list box of current grants
-            //txtTotalGrants.Text = total.ToString("C");                      // Also display total of all grants
             // Project Director
             FillProjectDirectorDDL();
             return;
@@ -201,9 +189,10 @@ namespace Portal11.Admin
         {
             record.Name = txtName.Text;
             record.Inactive = chkInact.Checked;
+            record.Code = txtCode.Text.ToUpper();                       // Force Code to upper case
             record.Description = txtDescription.Text;
             if (txtBalanceDate.Text == "")                              // If == field is blank. Supply default
-                record.BalanceDate = System.DateTime.Now;                   // Default date as now.
+                record.BalanceDate = System.DateTime.Now;               // Default date as now.
             else
                 record.BalanceDate = DateActions.LoadTxtIntoDate(txtBalanceDate); // Carefully convert the text into a date
 

--- a/Portal11/Admin/EditProject.aspx.designer.cs
+++ b/Portal11/Admin/EditProject.aspx.designer.cs
@@ -67,6 +67,24 @@ namespace Portal11.Admin {
         protected global::System.Web.UI.WebControls.CheckBox chkInact;
         
         /// <summary>
+        /// pnlCode control.
+        /// </summary>
+        /// <remarks>
+        /// Auto-generated field.
+        /// To modify move field declaration from designer file to code-behind file.
+        /// </remarks>
+        protected global::System.Web.UI.WebControls.Panel pnlCode;
+        
+        /// <summary>
+        /// txtCode control.
+        /// </summary>
+        /// <remarks>
+        /// Auto-generated field.
+        /// To modify move field declaration from designer file to code-behind file.
+        /// </remarks>
+        protected global::System.Web.UI.WebControls.TextBox txtCode;
+        
+        /// <summary>
         /// pnlDescription control.
         /// </summary>
         /// <remarks>

--- a/Portal11/Admin/Main.aspx
+++ b/Portal11/Admin/Main.aspx
@@ -164,6 +164,14 @@
                             <a runat="server" href="~/Select/SelectUser.aspx?Command=Assign" 
                                 title="Choose a Portal User and change their role (Project Director or Project Staff) on existing Projects">Assign Portal User to Project</a>
                         </li>
+                        <li class="list-group-item">
+                            <a runat="server" href="~/Lists/ImportProjectBalances" 
+                                title="Read and import a CSV file of project balance dates and balances">Import Project Balances</a>
+                        </li>
+                        <li class="list-group-item">
+                            <a runat="server" href="~/Lists/ListProjects.aspx" 
+                                title="List all the Projects in a printable format">List Projects</a>
+                        </li>
                     </ul>
                 </div>
             </div>

--- a/Portal11/App_Readme/WhatsNew.txt
+++ b/Portal11/App_Readme/WhatsNew.txt
@@ -1,4 +1,10 @@
-﻿﻿Version 1.1
+﻿Version 1.2
+
+An Expense Requests can be labeled "Rush" in its Delivery Instructions. Rush requests appear in red on the Project Dashboard and Staff Dashboard.
+On the Admin page, the new List Projects function creates a printable list of all projects.
+Projects now contain 3-letter codes that identify them in the accounting system. Edit Project can set this code. The new Admin function List Projects displays the code. And the new Admin function Import Project Balances reads a CSV file of codes, balance dates, and current funds and updates the projects.
+
+﻿Version 1.1
 
 For Entities, GL Codes, Persons, and Projects, the Portal now requires that names be unique. That is, duplicate names are not allowed.
 In all Grids, the number of rows per page is now controlled by a user-specific parameter. This can be adjusted on the Edit Portal User page.

--- a/Portal11/Lists/ListPortalUsers.aspx.cs
+++ b/Portal11/Lists/ListPortalUsers.aspx.cs
@@ -71,8 +71,13 @@ namespace Portal11.Lists
                 // Build a predicate that accounts for the Inactive check box and the Search txe box.
 
                 var pred = PredicateBuilder.True<ApplicationUser>();    // Initialize predicate to select from User table
+
+                string fran = SupportingActions.GetFranchiseKey();      // Fetch current franchise key
+                pred = pred.And(p => p.FranchiseKey == fran);           // Show only Users for this franchise
+
                 if (!chkInactive.Checked)                               // If false, we do not want Inactive Users
                     pred = pred.And(p => !p.Inactive);                  // Only active Users
+
                 string search = txtUser.Text;                           // Fetch the string that the user typed in, if any
                 if (search != "")                                       // If != the search string is not blank, use a Contains clause
                     pred = pred.And(p => p.FullName.Contains(search));  // Only Users whose name match our search criteria

--- a/Portal11/Models/PortalModels.cs
+++ b/Portal11/Models/PortalModels.cs
@@ -2,6 +2,7 @@
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel;
 using System.ComponentModel.DataAnnotations.Schema;
+using System.Drawing;
 
 namespace Portal11.Models
 {
@@ -45,6 +46,33 @@ namespace Portal11.Models
         public DateTime LastLogin { get; set; }
         public string Inactive { get; set; }
         public const int InactiveColumn = 7;
+    }
+
+    // One row of the GridView named AllPortalUsers, used by ListPortalUsers
+
+    public class AllProjectsRow
+    {
+        public string Code { get; set; }
+        public string Name { get; set; }
+        public string Description { get; set; }
+        public DateTime CreatedTime { get; set; }
+        public DateTime BalanceDate { get; set; }
+        public string CurrentFunds { get; set; }
+        public string ProjectDirector { get; set; }
+        public int TotalRequests { get; set; }
+        public string Inactive { get; set; }
+        public const int InactiveColumn = 8;
+    }
+
+    // One row of the GridView named ImportCSV, used by ImportProjectBalance
+
+    public class ImportCSVRow
+    {
+        public string ProjectCode { get; set; }
+        public string BalanceDate { get; set; }
+        public string CurrentFunds { get; set; }
+        public string Status { get; set; }
+        public bool Error { get; set; }
     }
 
     // One row of the GridView named AllAppView, used by ProjectDashboard
@@ -99,6 +127,7 @@ namespace Portal11.Models
         public const int CurrentStateDescRow = 7;
         public string ReturnNote { get; set; }
         public bool Archived { get; set; }
+        public bool Rush { get; set; }
     }
 
     // One row of the GridViews named AllProjectView, used by SelectProject
@@ -107,6 +136,7 @@ namespace Portal11.Models
     {
         public string ProjectID { get; set; }
         public string Inactive { get; set; }
+        public string Code { get; set; }
         public string Name { get; set; }
         public string Description { get; set; }
         public int Count { get; set; }
@@ -178,6 +208,7 @@ namespace Portal11.Models
         public string Summary { get; set; }
         public string ReturnNote { get; set; }
         public bool Archived { get; set; }
+        public bool Rush { get; set; }
     }
 
     // One row of the GridView named UserProjectView, used by AssignUserToProject
@@ -575,6 +606,7 @@ namespace Portal11.Models
         public string ReturnNote { get; set; }              // When approval is denied, the reason goes here
 
         public bool Rush { get; set; }                      // Whether the Request has "Rush" status
+        public const string DeliveryInstructionsRush = "Rush";
 
         public SourceOfExpFunds SourceOfFunds { get; set; } // Where the Request gets its Funds
         public int? ProjectClassID { get; set; }
@@ -1296,6 +1328,7 @@ namespace Portal11.Models
             CYes = "Yes",
             CNo = "No",
             CNone = "None",
+            CSVFileName = "Uploaded CSV File.CSV", CSVExt = ".CSV", CSVType = "APPLICATION/VND.MS-EXCEL",
             POVendorModeYes = "Yes",
             POVendorModeNo = "No",
             PODeliveryModePickup = "Pickup",

--- a/Portal11/Portal11.csproj
+++ b/Portal11/Portal11.csproj
@@ -47,6 +47,7 @@
       <HintPath>..\packages\LINQKit.1.1.2\lib\net45\LinqKit.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
+    <Reference Include="Microsoft.VisualBasic" />
     <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System" />
     <Reference Include="System.Data" />
@@ -192,7 +193,9 @@
     <Content Include="ErrorLog\FatalError.aspx" />
     <Content Include="Images\LoginBackground-1024x768.jpg" />
     <Content Include="Images\LoginIcon-640x480.jpg" />
+    <Content Include="Lists\ImportProjectBalances.aspx" />
     <Content Include="Lists\ListPortalUsers.aspx" />
+    <Content Include="Lists\ListProjects.aspx" />
     <Content Include="Proj\EditProjectClass.aspx" />
     <Content Include="Proj\TestModal.aspx" />
     <Content Include="Rqsts\EditApproval.aspx" />
@@ -526,12 +529,26 @@
     <Compile Include="ErrorLog\LogError.cs">
       <SubType>ASPXCodeBehind</SubType>
     </Compile>
+    <Compile Include="Lists\ImportProjectBalances.aspx.cs">
+      <DependentUpon>ImportProjectBalances.aspx</DependentUpon>
+      <SubType>ASPXCodeBehind</SubType>
+    </Compile>
+    <Compile Include="Lists\ImportProjectBalances.aspx.designer.cs">
+      <DependentUpon>ImportProjectBalances.aspx</DependentUpon>
+    </Compile>
     <Compile Include="Lists\ListPortalUsers.aspx.cs">
       <DependentUpon>ListPortalUsers.aspx</DependentUpon>
       <SubType>ASPXCodeBehind</SubType>
     </Compile>
     <Compile Include="Lists\ListPortalUsers.aspx.designer.cs">
       <DependentUpon>ListPortalUsers.aspx</DependentUpon>
+    </Compile>
+    <Compile Include="Lists\ListProjects.aspx.cs">
+      <DependentUpon>ListProjects.aspx</DependentUpon>
+      <SubType>ASPXCodeBehind</SubType>
+    </Compile>
+    <Compile Include="Lists\ListProjects.aspx.designer.cs">
+      <DependentUpon>ListProjects.aspx</DependentUpon>
     </Compile>
     <Compile Include="Logic\CookieActions.cs" />
     <Compile Include="Logic\DateActions.cs" />

--- a/Portal11/Proj/ProjectDashboard.aspx
+++ b/Portal11/Proj/ProjectDashboard.aspx
@@ -596,6 +596,11 @@
                                 <asp:Label ID="lblArchived" runat="server" Text='<%# Bind("Archived") %>'></asp:Label>
                             </ItemTemplate>
                         </asp:TemplateField>
+                        <asp:TemplateField HeaderText="Rush" Visible="false">
+                            <ItemTemplate>
+                                <asp:Label ID="lblRush" runat="server" Text='<%# Bind("Rush") %>'></asp:Label>
+                            </ItemTemplate>
+                        </asp:TemplateField>
                     </Columns>
                 </asp:GridView>
 

--- a/Portal11/Proj/ProjectDashboard.aspx.cs
+++ b/Portal11/Proj/ProjectDashboard.aspx.cs
@@ -9,6 +9,7 @@ using Portal11.Models;
 using Portal11.Logic;
 using System.Data;
 using Portal11.ErrorLog;
+using System.Drawing;
 
 namespace Portal11.Proj
 {
@@ -477,6 +478,12 @@ namespace Portal11.Proj
                 label = (Label)e.Row.FindControl("lblArchived");            // Find the label control that contains Archived in this row
                 if (label.Text == "True")                                   // If == this record is Archived
                     e.Row.Font.Italic = true;                               // Use italics to indicate Archived status
+
+                // See if the row is Rush
+
+                label = (Label)e.Row.FindControl("lblRush");                // Find the label control that contains Rush in this row
+                if (label.Text == "True")                                   // If == this record is Rush
+                    e.Row.ForeColor = Color.Red;                            // Use color to indicate Rush status
             }
             return;
         }
@@ -1649,7 +1656,8 @@ namespace Portal11.Proj
                         Amount = ExtensionActions.LoadDecimalIntoTxt(r.Amount), // Carefully load decimal amount into text field
                         CurrentState = r.CurrentState,                  // Load enum version for use when row is selected
                         CurrentStateDesc = EnumActions.GetEnumDescription(r.CurrentState), // Convert enum version to English version for display
-                        Archived = r.Archived                           // Whether the request is archived
+                        Archived = r.Archived,                          // Whether the request is archived
+                        Rush = r.Rush                                   // Whether the request is Rush
                     };
 
                     // Fill "Target" with Vendor Name or Person Name. Only one will be present, depending on ExpType.

--- a/Portal11/Properties/AssemblyInfo.cs
+++ b/Portal11/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 //
 // You can specify all the values or you can default the Revision and Build Numbers 
 // by using the '*' as shown below:
-[assembly: AssemblyVersion("1.1.*")]
+[assembly: AssemblyVersion("1.2.*")]
 [assembly: AssemblyFileVersion("1.0.0.0")]

--- a/Portal11/Rqsts/EditExpense.aspx
+++ b/Portal11/Rqsts/EditExpense.aspx
@@ -654,12 +654,18 @@
                     <div class="panel panel-default col-lg-3 col-md-4 col-sm-offset-0 col-xs-offset-1 col-xs-6">
                         <div class="radio">
                             <asp:RadioButtonList ID="rdoDeliveryMode" runat="server" AutoPostBack="true"
-                                Style="margin-left: 20px; margin-bottom: 10px;" CssClass="rdoColWidth" Visible="true"
+                                Style="margin-left: 20px;" CssClass="rdoColWidth" Visible="true"
                                 OnSelectedIndexChanged="rdoDeliveryMode_SelectedIndexChanged">
                                 <asp:ListItem Text="Hold for pickup." Value="Pickup" Selected="True"></asp:ListItem>
                                 <asp:ListItem Text="Mail to payee." Value="MailPayee"></asp:ListItem>
                                 <asp:ListItem Text="Mail to the below address." Value="MailAddress"></asp:ListItem>
                             </asp:RadioButtonList>
+                        </div>
+                        <div class="checkbox text-danger" >
+                            <asp:CheckBoxList ID="cblDeliveryInstructions" runat="server" Style="margin-left: 20px; margin-bottom: 10px">
+                                <asp:ListItem Text="Rush" Value="Rush" data-toggle="tooltip"
+                                    title="Please process this request as quickly as possible"></asp:ListItem>
+                            </asp:CheckBoxList>
                         </div>
                     </div>
                 </div>

--- a/Portal11/Rqsts/EditExpense.aspx.cs
+++ b/Portal11/Rqsts/EditExpense.aspx.cs
@@ -1078,6 +1078,7 @@ namespace Portal11.Rqsts
                     pnlDeliveryAddress.Visible = true;                      // Turn on the Delivery Address
                     txtDeliveryAddress.Text = record.DeliveryAddress;       // And fill it
                 }
+                cblDeliveryInstructions.Items.FindByValue(Exp.DeliveryInstructionsRush).Selected = record.Rush; // Fill value of checkbox
             }
 
             txtDescription.Text = record.Description;
@@ -1201,7 +1202,10 @@ namespace Portal11.Rqsts
                 record.DeliveryAddress = txtDeliveryAddress.Text;
 
             if (pnlDeliveryInstructions.Visible)
+            {
                 record.DeliveryMode = EnumActions.ConvertTextToDeliveryMode(rdoDeliveryMode.SelectedValue); // Convert selection to enum
+                record.Rush = cblDeliveryInstructions.Items.FindByValue(Exp.DeliveryInstructionsRush).Selected; // Stash value of checkbox
+            }
 
             record.Description = txtDescription.Text;
 

--- a/Portal11/Rqsts/EditExpense.aspx.designer.cs
+++ b/Portal11/Rqsts/EditExpense.aspx.designer.cs
@@ -688,6 +688,15 @@ namespace Portal11.Rqsts {
         protected global::System.Web.UI.WebControls.RadioButtonList rdoDeliveryMode;
         
         /// <summary>
+        /// cblDeliveryInstructions control.
+        /// </summary>
+        /// <remarks>
+        /// Auto-generated field.
+        /// To modify move field declaration from designer file to code-behind file.
+        /// </remarks>
+        protected global::System.Web.UI.WebControls.CheckBoxList cblDeliveryInstructions;
+        
+        /// <summary>
         /// pnlDeliveryAddress control.
         /// </summary>
         /// <remarks>

--- a/Portal11/Select/SelectProject.aspx
+++ b/Portal11/Select/SelectProject.aspx
@@ -92,7 +92,12 @@
                                 <asp:Label ID="lblRowID" runat="server" Text='<%# Bind("ProjectID") %>'></asp:Label>
                             </ItemTemplate>
                         </asp:TemplateField>
-                         <asp:TemplateField HeaderText="Project Name">
+                        <asp:TemplateField HeaderText="Project Code">
+                            <ItemTemplate>
+                                <asp:Label ID="lblCode" runat="server" Text='<%# Bind("Code") %>'></asp:Label>
+                            </ItemTemplate>
+                        </asp:TemplateField>
+                        <asp:TemplateField HeaderText="Project Name">
                             <ItemTemplate>
                                 <asp:Label ID="lblName" runat="server" Text='<%# Bind("Name") %>'></asp:Label>
                             </ItemTemplate>

--- a/Portal11/Select/SelectProject.aspx.cs
+++ b/Portal11/Select/SelectProject.aspx.cs
@@ -311,6 +311,7 @@ namespace Portal11.Staff
 
                     if (!chkInactive.Checked)                               // If false, we do not want Inactive Projects
                         pred = pred.And(p => !p.Inactive);                  // Only active Projects
+
                     string search = txtProject.Text;                        // Fetch the string that the user typed in, if any
                     if (search != "")                                       // If != the search string is not blank, use a Contains clause
                         pred = pred.And(p => p.Name.Contains(search));      // Only Projects whose name match our search criteria
@@ -327,6 +328,7 @@ namespace Portal11.Staff
                     {
                         SelectProjectAllViewRow row = new SelectProjectAllViewRow();    // Instantiate empty row all ready to fill
                         row.ProjectID = p.ProjectID.ToString();             // Fill the part of the row that's always there
+                        row.Code = p.Code;
                         row.Name = p.Name;
                         row.Description = p.Description;
                         row.Inactive = p.Inactive.ToString();

--- a/Portal11/Staff/StaffDashboard.aspx
+++ b/Portal11/Staff/StaffDashboard.aspx
@@ -269,6 +269,7 @@
                             OnPageIndexChanging="StaffAppView_PageIndexChanging">
 
                             <SelectedRowStyle CssClass="success" />
+                            <HeaderStyle HorizontalAlign="Center" />
 
                             <PagerStyle CssClass="active" HorizontalAlign="Center"></PagerStyle>
                             <PagerTemplate>
@@ -294,14 +295,13 @@
                                 </table>
                             </EmptyDataTemplate>
                             <Columns>
-                                <%-- Code assumes that RowID is column 0 and CurrentState is in column 4--%>
                                 <asp:TemplateField HeaderText="ID" Visible="false">
                                     <ItemTemplate>
                                         <asp:Label ID="lblRowID" runat="server" Text='<%# Bind("RowID") %>'></asp:Label>
                                     </ItemTemplate>
                                 </asp:TemplateField>
-                                <asp:BoundField DataField="CurrentTime" HeaderText="Last Modified" DataFormatString="{0:MM/dd/yyyy}" />
-                                <asp:BoundField DataField="ProjectName" HeaderText="Project" />
+                                <asp:BoundField DataField="CurrentTime" ItemStyle-HorizontalAlign="Right" HeaderText="Last Modified" DataFormatString="{0:MM/dd/yyyy}" />
+                                <asp:BoundField DataField="ProjectName" ItemStyle-HorizontalAlign="Left" HeaderText="Project" HeaderStyle-HorizontalAlign="Right"/>
                                 <asp:BoundField DataField="AppTypeDesc" HeaderText="Approval Type" />
                                 <asp:BoundField DataField="AppReviewType" HeaderText="Review Type" />
                                 <asp:TemplateField HeaderText="Status" Visible="false">
@@ -422,13 +422,12 @@
                                 </table>
                             </EmptyDataTemplate>
                             <Columns>
-                                <%-- Code assumes that RowID is column 0 and CurrentState is in column 4--%>
                                 <asp:TemplateField HeaderText="ID" Visible="false">
                                     <ItemTemplate>
                                         <asp:Label ID="lblRowID" runat="server" Text='<%# Bind("RowID") %>'></asp:Label>
                                     </ItemTemplate>
                                 </asp:TemplateField>
-                                <asp:BoundField DataField="CurrentTime" HeaderText="Last Modified" DataFormatString="{0:MM/dd/yyyy}" />
+                                <asp:BoundField DataField="CurrentTime" ItemStyle-HorizontalAlign="Right" HeaderText="Last Modified" DataFormatString="{0:MM/dd/yyyy}" />
                                 <asp:BoundField DataField="ProjectName" HeaderText="Project" />
                                 <asp:BoundField DataField="DepTypeDesc" HeaderText="Deposit Type" />
                                 <asp:BoundField DataField="Amount" HeaderText="Amount" DataFormatString="${0:###,###.00}"
@@ -553,16 +552,14 @@
                                 </table>
                             </EmptyDataTemplate>
                             <Columns>
-                                <%-- Code assumes that RowID is column 0 and CurrentState is in column 4--%>
                                 <asp:TemplateField HeaderText="ID" Visible="false">
                                     <ItemTemplate>
                                         <asp:Label ID="lblRowID" runat="server" Text='<%# Bind("RowID") %>'></asp:Label>
                                     </ItemTemplate>
                                 </asp:TemplateField>
-                                <asp:BoundField DataField="CurrentTime" HeaderText="Last Modified" DataFormatString="{0:MM/dd/yyyy}" />
+                                <asp:BoundField DataField="CurrentTime" ItemStyle-HorizontalAlign="Right" HeaderText="Last Modified" DataFormatString="{0:MM/dd/yyyy}" />
                                 <asp:BoundField DataField="ProjectName" HeaderText="Project" />
                                 <asp:BoundField DataField="ExpTypeDesc" HeaderText="Expense Type" />
-                                <%--                                <asp:BoundField DataField="Summary" HeaderText="Summary" />--%>
                                 <asp:BoundField DataField="Amount" HeaderText="Amount" DataFormatString="${0:###,###.00}"
                                     HtmlEncode="false" ItemStyle-HorizontalAlign="Right" />
                                 <asp:TemplateField HeaderText="Status" Visible="false">
@@ -576,6 +573,11 @@
                                 <asp:TemplateField HeaderText="Archived" Visible="false">
                                     <ItemTemplate>
                                         <asp:Label ID="lblArchived" runat="server" Text='<%# Bind("Archived") %>'></asp:Label>
+                                    </ItemTemplate>
+                                </asp:TemplateField>
+                                <asp:TemplateField HeaderText="Rush" Visible="false">
+                                    <ItemTemplate>
+                                        <asp:Label ID="lblRush" runat="server" Text='<%# Bind("Rush") %>'></asp:Label>
                                     </ItemTemplate>
                                 </asp:TemplateField>
                             </Columns>

--- a/Portal11/Staff/StaffDashboard.aspx.cs
+++ b/Portal11/Staff/StaffDashboard.aspx.cs
@@ -9,6 +9,7 @@ using Portal11.Logic;
 using Portal11.ErrorLog;
 using System.Data;
 using LinqKit;
+using System.Drawing;
 
 namespace Portal11.Rqsts
 {
@@ -23,9 +24,6 @@ namespace Portal11.Rqsts
         {
             if (!Page.IsPostBack)
             {
-//                LogError.LogInternalError("StaffDashboard", $"Invalid AppType in ApprovalID "); // Log fatal error
-                //int badone = 1, badzero = 0;
-                //int badquotient = badone / badzero;
 
                 // If the page before us has left a Query String with a status message, find it and display it
 
@@ -431,6 +429,12 @@ namespace Portal11.Rqsts
                 label = (Label)e.Row.FindControl("lblArchived");                // Find the label control that contains Archived in this row
                 if (label.Text == "True")                                       // If == this record is Archived
                     e.Row.Font.Italic = true;                                   // Use italics to indicate Archived status
+
+                // See if the row is Rush
+
+                label = (Label)e.Row.FindControl("lblRush");                    // Find the label control that contains Rush in this row
+                if (label.Text == "True")                                       // If == this record is Rush
+                    e.Row.ForeColor = Color.Red;                                // Use color to indicate Rush status
             }
             return;
         }
@@ -1122,7 +1126,8 @@ namespace Portal11.Rqsts
                                 CurrentState = r.CurrentState,              // Put this in so we can get it out later to dispatch; it's not Visible
                                 CurrentStateDesc = EnumActions.GetEnumDescription(r.CurrentState), // Convert enum form to English for display
                                 ReturnNote = r.ReturnNote,
-                                Owner = EnumActions.GetEnumDescription(own) // Fetch "English" version of owner
+                                Owner = EnumActions.GetEnumDescription(own), // Fetch "English" version of owner
+                                Rush = r.Rush                               // Whether the Request is a "Rush"
                             };
 
                             // Fill "Target" with Vendor Name or Employee Name or Recipient. Only one will be present, depending on RqstType.


### PR DESCRIPTION
An Expense Requests can be labeled "Rush" in its Delivery Instructions. Rush requests appear in red on the Project Dashboard and Staff Dashboard.
On the Admin page, the new List Projects function creates a printable list of all projects.
Projects now contain 3-letter codes that identify them in the accounting system. Edit Project can set this code. The new Admin function List Projects displays the code. And the new Admin function Import Project Balances reads a CSV file of codes, balance dates, and current funds and updates the projects.
